### PR TITLE
stop using deprecated library calls

### DIFF
--- a/src/kzg/kzg.ts
+++ b/src/kzg/kzg.ts
@@ -26,7 +26,7 @@ export async function blobToKZGCommitment(blob: Uint8Array): Promise<Uint8Array>
   }
 
   const coefficients = blobToFieldElements(blob);
-  let commitment = bls.G1.ProjectivePoint.ZERO;
+  let commitment = bls.G1.Point.ZERO;
 
   for (let i = 0; i < coefficients.length; i++) {
     if (coefficients[i] === Fr.ZERO) continue;
@@ -35,7 +35,7 @@ export async function blobToKZGCommitment(blob: Uint8Array): Promise<Uint8Array>
     commitment = commitment.add(term);
   }
 
-  return commitment.toRawBytes(true);
+  return commitment.toBytes(true);
 }
 
 /**
@@ -55,7 +55,7 @@ export async function computeKZGProof(
   // Compute quotient polynomial: q(x) = (p(x) - y) / (x - z)
   const quotient = computeQuotient(coefficients, z, y);
 
-  let proof = bls.G1.ProjectivePoint.ZERO;
+  let proof = bls.G1.Point.ZERO;
   for (let i = 0; i < quotient.length; i++) {
     if (quotient[i] === Fr.ZERO) continue;
 
@@ -83,8 +83,8 @@ export async function verifyKZGProof(
   }
 
   try {
-    const C = bls.G1.ProjectivePoint.fromHex(commitment);
-    const pi = bls.G1.ProjectivePoint.fromHex(proof);
+    const C = bls.G1.Point.fromHex(commitment);
+    const pi = bls.G1.Point.fromHex(proof);
 
     const G1 = trustedSetup.g1Powers[0];
     const G2 = trustedSetup.g2Powers[0];
@@ -94,9 +94,9 @@ export async function verifyKZGProof(
     const C_minus_yG1 = y === Fr.ZERO ? C : C.subtract(G1.multiply(y));
     const G2_tau_minus_zG2 = z === Fr.ZERO ? G2_tau : G2_tau.subtract(G2.multiply(z));
 
-    const leftIsZero = C_minus_yG1.equals(bls.G1.ProjectivePoint.ZERO);
-    const rightIsZero = pi.equals(bls.G1.ProjectivePoint.ZERO);
-    
+    const leftIsZero = C_minus_yG1.equals(bls.G1.Point.ZERO);
+    const rightIsZero = pi.equals(bls.G1.Point.ZERO);
+
     if (leftIsZero && rightIsZero) return true;
     if (leftIsZero || rightIsZero) return false;
 

--- a/src/kzg/setup.ts
+++ b/src/kzg/setup.ts
@@ -5,8 +5,8 @@ import { TrustedSetup } from './types';
 import { FIELD_ELEMENTS_PER_BLOB } from './constants';
 import { Fr } from './field';
 
-type G1Point = ReturnType<typeof bls.G1.ProjectivePoint.fromHex>;
-type G2Point = ReturnType<typeof bls.G2.ProjectivePoint.fromHex>;
+type G1Point = ReturnType<typeof bls.G1.Point.fromHex>;
+type G2Point = ReturnType<typeof bls.G2.Point.fromHex>;
 
 /**
  * Load trusted setup from binary files.
@@ -56,7 +56,7 @@ export async function loadTrustedSetupFromText(
 
   const g1Powers = g1Lines.map((hex, i) => {
     try {
-      return bls.G1.ProjectivePoint.fromHex(hex.trim());
+      return bls.G1.Point.fromHex(hex.trim());
     } catch (e) {
       throw new BlobKitError(
         `Invalid G1 point at line ${i + 1}`,
@@ -67,7 +67,7 @@ export async function loadTrustedSetupFromText(
 
   const g2Powers = g2Lines.map((hex, i) => {
     try {
-      return bls.G2.ProjectivePoint.fromHex(hex.trim());
+      return bls.G2.Point.fromHex(hex.trim());
     } catch (e) {
       throw new BlobKitError(
         `Invalid G2 point at line ${i + 1}`,
@@ -91,9 +91,9 @@ export function createMockSetup(): TrustedSetup {
 
   let power = Fr.ONE;
   for (let i = 0; i < FIELD_ELEMENTS_PER_BLOB; i++) {
-    g1Powers.push(bls.G1.ProjectivePoint.BASE.multiply(power));
+    g1Powers.push(bls.G1.Point.BASE.multiply(power));
     if (i < 2) {
-      g2Powers.push(bls.G2.ProjectivePoint.BASE.multiply(power));
+      g2Powers.push(bls.G2.Point.BASE.multiply(power));
     }
     power = Fr.mul(power, tau);
   }
@@ -114,7 +114,7 @@ function parseG1Points(data: Buffer, count: number): G1Point[] {
   for (let i = 0; i < count; i++) {
     const start = i * pointSize;
     const pointData = data.subarray(start, start + pointSize);
-    points.push(bls.G1.ProjectivePoint.fromHex(pointData));
+    points.push(bls.G1.Point.fromHex(pointData));
   }
   return points;
 }
@@ -132,18 +132,18 @@ function parseG2Points(data: Buffer, count: number): G2Point[] {
   for (let i = 0; i < count; i++) {
     const start = i * pointSize;
     const pointData = data.subarray(start, start + pointSize);
-    points.push(bls.G2.ProjectivePoint.fromHex(pointData));
+    points.push(bls.G2.Point.fromHex(pointData));
   }
   return points;
 }
 
 function validateSetup(g1Powers: G1Point[], g2Powers: G2Point[]): void {
   // First elements should be generators
-  if (!g1Powers[0].equals(bls.G1.ProjectivePoint.BASE)) {
+  if (!g1Powers[0].equals(bls.G1.Point.BASE)) {
     throw new BlobKitError('First G1 power must be generator', 'INVALID_SETUP');
   }
 
-  if (!g2Powers[0].equals(bls.G2.ProjectivePoint.BASE)) {
+  if (!g2Powers[0].equals(bls.G2.Point.BASE)) {
     throw new BlobKitError('First G2 power must be generator', 'INVALID_SETUP');
   }
 }

--- a/test/kzg/setup-files.test.ts.disabled
+++ b/test/kzg/setup-files.test.ts.disabled
@@ -21,9 +21,9 @@ describe('Setup File Loading', () => {
   describe('loadTrustedSetupFromBinary', () => {
     it('should load valid binary files', async () => {
       // Create valid binary data
-      const g1Gen = bls.G1.ProjectivePoint.BASE.toRawBytes(true);
-      const g2Gen = bls.G2.ProjectivePoint.BASE.toRawBytes(true);
-      const g2Tau = bls.G2.ProjectivePoint.BASE.multiply(12345n).toRawBytes(true);
+      const g1Gen = bls.G1.Point.BASE.toRawBytes(true);
+      const g2Gen = bls.G2.Point.BASE.toRawBytes(true);
+      const g2Tau = bls.G2.Point.BASE.multiply(12345n).toRawBytes(true);
       
       // Mock G1 data (4096 points)
       const g1Data = Buffer.alloc(4096 * 48);
@@ -42,8 +42,8 @@ describe('Setup File Loading', () => {
       
       expect(setup.g1Powers).toHaveLength(4096);
       expect(setup.g2Powers).toHaveLength(2);
-      expect(setup.g1Powers[0].equals(bls.G1.ProjectivePoint.BASE)).toBe(true);
-      expect(setup.g2Powers[0].equals(bls.G2.ProjectivePoint.BASE)).toBe(true);
+      expect(setup.g1Powers[0].equals(bls.G1.Point.BASE)).toBe(true);
+      expect(setup.g2Powers[0].equals(bls.G2.Point.BASE)).toBe(true);
     });
 
     it('should reject G1 file with wrong size', async () => {
@@ -76,7 +76,7 @@ describe('Setup File Loading', () => {
       // Fill with invalid data (all 0xFF)
       g1Data.fill(0xFF, 0, 48);
       
-      const g2Gen = bls.G2.ProjectivePoint.BASE.toRawBytes(true);
+      const g2Gen = bls.G2.Point.BASE.toRawBytes(true);
       const g2Data = Buffer.concat([g2Gen, g2Gen]);
       
       mockReadFile
@@ -89,8 +89,8 @@ describe('Setup File Loading', () => {
 
     it('should reject setup with non-generator first G1', async () => {
       // First G1 is not the generator
-      const notGen = bls.G1.ProjectivePoint.BASE.multiply(2n).toRawBytes(true);
-      const g1Gen = bls.G1.ProjectivePoint.BASE.toRawBytes(true);
+      const notGen = bls.G1.Point.BASE.multiply(2n).toRawBytes(true);
+      const g1Gen = bls.G1.Point.BASE.toRawBytes(true);
       
       const g1Data = Buffer.alloc(4096 * 48);
       g1Data.set(notGen, 0); // First is not generator
@@ -98,7 +98,7 @@ describe('Setup File Loading', () => {
         g1Data.set(g1Gen, i * 48);
       }
       
-      const g2Gen = bls.G2.ProjectivePoint.BASE.toRawBytes(true);
+      const g2Gen = bls.G2.Point.BASE.toRawBytes(true);
       const g2Data = Buffer.concat([g2Gen, g2Gen]);
       
       mockReadFile
@@ -110,15 +110,15 @@ describe('Setup File Loading', () => {
     });
 
     it('should reject setup with non-generator first G2', async () => {
-      const g1Gen = bls.G1.ProjectivePoint.BASE.toRawBytes(true);
+      const g1Gen = bls.G1.Point.BASE.toRawBytes(true);
       const g1Data = Buffer.alloc(4096 * 48);
       for (let i = 0; i < 4096; i++) {
         g1Data.set(g1Gen, i * 48);
       }
       
       // First G2 is not generator
-      const notGen = bls.G2.ProjectivePoint.BASE.multiply(2n).toRawBytes(true);
-      const g2Gen = bls.G2.ProjectivePoint.BASE.toRawBytes(true);
+      const notGen = bls.G2.Point.BASE.multiply(2n).toRawBytes(true);
+      const g2Gen = bls.G2.Point.BASE.toRawBytes(true);
       const g2Data = Buffer.concat([notGen, g2Gen]);
       
       mockReadFile
@@ -139,9 +139,9 @@ describe('Setup File Loading', () => {
 
   describe('loadTrustedSetupFromText', () => {
     it('should load valid text files', async () => {
-      const g1Hex = bls.G1.ProjectivePoint.BASE.toHex();
-      const g2Hex = bls.G2.ProjectivePoint.BASE.toHex();
-      const g2TauHex = bls.G2.ProjectivePoint.BASE.multiply(12345n).toHex();
+      const g1Hex = bls.G1.Point.BASE.toHex();
+      const g2Hex = bls.G2.Point.BASE.toHex();
+      const g2TauHex = bls.G2.Point.BASE.multiply(12345n).toHex();
       
       // Create text content
       const g1Content = Array(4096).fill(g1Hex).join('\n');
@@ -155,13 +155,13 @@ describe('Setup File Loading', () => {
       
       expect(setup.g1Powers).toHaveLength(4096);
       expect(setup.g2Powers).toHaveLength(2);
-      expect(setup.g1Powers[0].equals(bls.G1.ProjectivePoint.BASE)).toBe(true);
-      expect(setup.g2Powers[0].equals(bls.G2.ProjectivePoint.BASE)).toBe(true);
+      expect(setup.g1Powers[0].equals(bls.G1.Point.BASE)).toBe(true);
+      expect(setup.g2Powers[0].equals(bls.G2.Point.BASE)).toBe(true);
     });
 
     it('should handle empty lines and whitespace', async () => {
-      const g1Hex = bls.G1.ProjectivePoint.BASE.toHex();
-      const g2Hex = bls.G2.ProjectivePoint.BASE.toHex();
+      const g1Hex = bls.G1.Point.BASE.toHex();
+      const g2Hex = bls.G2.Point.BASE.toHex();
       
       // Add empty lines and whitespace
       const g1Lines = [];
@@ -198,7 +198,7 @@ describe('Setup File Loading', () => {
     });
 
     it('should reject file with wrong number of G2 points', async () => {
-      const g1Hex = bls.G1.ProjectivePoint.BASE.toHex();
+      const g1Hex = bls.G1.Point.BASE.toHex();
       const g1Content = Array(4096).fill(g1Hex).join('\n');
       const g2Content = '0x123\n0x456\n0x789'; // 3 points instead of 2
       
@@ -211,11 +211,11 @@ describe('Setup File Loading', () => {
     });
 
     it('should reject invalid hex in G1 file', async () => {
-      const g1Hex = bls.G1.ProjectivePoint.BASE.toHex();
+      const g1Hex = bls.G1.Point.BASE.toHex();
       const g1Lines = Array(4095).fill(g1Hex);
       g1Lines.push('invalid-hex-data'); // Invalid on last line
       
-      const g2Hex = bls.G2.ProjectivePoint.BASE.toHex();
+      const g2Hex = bls.G2.Point.BASE.toHex();
       const g2Content = `${g2Hex}\n${g2Hex}`;
       
       mockReadFile
@@ -227,10 +227,10 @@ describe('Setup File Loading', () => {
     });
 
     it('should reject invalid hex in G2 file', async () => {
-      const g1Hex = bls.G1.ProjectivePoint.BASE.toHex();
+      const g1Hex = bls.G1.Point.BASE.toHex();
       const g1Content = Array(4096).fill(g1Hex).join('\n');
       
-      const g2Hex = bls.G2.ProjectivePoint.BASE.toHex();
+      const g2Hex = bls.G2.Point.BASE.toHex();
       const g2Content = `${g2Hex}\ninvalid-g2-point`;
       
       mockReadFile
@@ -242,8 +242,8 @@ describe('Setup File Loading', () => {
     });
 
     it('should handle various line endings', async () => {
-      const g1Hex = bls.G1.ProjectivePoint.BASE.toHex();
-      const g2Hex = bls.G2.ProjectivePoint.BASE.toHex();
+      const g1Hex = bls.G1.Point.BASE.toHex();
+      const g2Hex = bls.G2.Point.BASE.toHex();
       
       // Mix different line endings
       const g1Lines = Array(4096).fill(g1Hex);
@@ -262,8 +262,8 @@ describe('Setup File Loading', () => {
     });
 
     it('should trim whitespace from hex values', async () => {
-      const g1Hex = bls.G1.ProjectivePoint.BASE.toHex();
-      const g2Hex = bls.G2.ProjectivePoint.BASE.toHex();
+      const g1Hex = bls.G1.Point.BASE.toHex();
+      const g2Hex = bls.G2.Point.BASE.toHex();
       
       // Add spaces and tabs
       const g1Lines = Array(4096).fill(`  ${g1Hex}\t `);

--- a/test/kzg/setup.test.ts
+++ b/test/kzg/setup.test.ts
@@ -11,8 +11,8 @@ describe('Trusted Setup', () => {
       expect(setup.g2Powers).toHaveLength(2);
       
       // First elements should be generators
-      expect(setup.g1Powers[0].equals(bls.G1.ProjectivePoint.BASE)).toBe(true);
-      expect(setup.g2Powers[0].equals(bls.G2.ProjectivePoint.BASE)).toBe(true);
+      expect(setup.g1Powers[0].equals(bls.G1.Point.BASE)).toBe(true);
+      expect(setup.g2Powers[0].equals(bls.G2.Point.BASE)).toBe(true);
     });
 
     it('should create powers of tau', () => {

--- a/test/utils/kzg-vectors.test.ts
+++ b/test/utils/kzg-vectors.test.ts
@@ -28,7 +28,7 @@ describe('KZG Test Vectors', () => {
       expect(commitment.length).toBe(48);
       
       // Zero blob should give zero/identity commitment
-      const zeroPoint = bls.G1.ProjectivePoint.ZERO.toRawBytes(true);
+      const zeroPoint = bls.G1.Point.ZERO.toRawBytes(true);
       expect(commitment).toEqual(zeroPoint);
     });
   });
@@ -42,7 +42,7 @@ describe('KZG Test Vectors', () => {
       expect(commitment).toBeInstanceOf(Uint8Array);
       
       // Should be G1 generator
-      const expected = bls.G1.ProjectivePoint.BASE.toRawBytes(true);
+      const expected = bls.G1.Point.BASE.toRawBytes(true);
       expect(commitment).toEqual(expected);
     });
 
@@ -53,7 +53,7 @@ describe('KZG Test Vectors', () => {
       const commitment = await blobToKZGCommitment(blob);
       
       // Should be 5 * G1
-      const expected = bls.G1.ProjectivePoint.BASE.multiply(5n).toRawBytes(true);
+      const expected = bls.G1.Point.BASE.multiply(5n).toRawBytes(true);
       expect(commitment).toEqual(expected);
     });
 


### PR DESCRIPTION
Replace deprecated calls with the new ones.


ProjectivePoint -> Point
toRawBytes -> toBytes